### PR TITLE
buf_size in BacktrackSearcher set to 10MB

### DIFF
--- a/whylog/client/const.py
+++ b/whylog/client/const.py
@@ -1,2 +1,2 @@
 class BufsizeConsts:
-    STANDARD_BUF_SIZE = 8192
+    STANDARD_BUF_SIZE = 1024 * 1024 * 10


### PR DESCRIPTION
according to issue #61
